### PR TITLE
Fix Tailwind integration and ensure Vite compatibility

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -48,8 +48,11 @@
     --ring: 263 70% 50%;
   }
 
-  * { @apply border-border; }
-  body { @apply bg-background text-foreground; }
+  * { border-color: hsl(var(--border)); }
+  body {
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
+  }
 }
 
 @layer components {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
-export default {
+const config = {
   darkMode: ["class"],
   content: [
     "./index.html",
@@ -83,7 +84,9 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 } satisfies Config;
+
+export default config;
 
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,22 +1,26 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    // Prefer TS/TSX files over JS when the same basename exists
-    extensions: [".tsx", ".ts", ".jsx", ".js", ".json"],
-  },
-  server: {
-    port: 5173,
-    strictPort: false,
-    proxy: {
-      "/api": {
-        target: "http://localhost:8000",
-        changeOrigin: true,
+export default defineConfig(async () => {
+  const tailwindcss = (await import("@tailwindcss/vite")).default;
+
+  return {
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      // Prefer TS/TSX files over JS when the same basename exists
+      extensions: [".tsx", ".ts", ".jsx", ".js", ".json"],
+    },
+    server: {
+      port: 5173,
+      strictPort: false,
+      proxy: {
+        "/api": {
+          target: "http://localhost:8000",
+          changeOrigin: true,
+        },
       },
     },
-  },
+  };
 });
 
 


### PR DESCRIPTION
## Summary
- load the tailwindcss-animate plugin through an ESM-friendly Tailwind config export
- enable Tailwind v4 processing in Vite via the official plugin and add Vite env typing support
- replace unsupported @apply usage in the base layer with CSS variables to satisfy Tailwind generation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1413c2c6c8331b8f10c6f5e4440ce